### PR TITLE
Change beforeEach to beforeAll for test isolation

### DIFF
--- a/src/config.test.js
+++ b/src/config.test.js
@@ -15,7 +15,7 @@ afterEach(() => {
   fs.readJSONSync = originalReadJSONSync
 })
 let configOptions
-beforeAll(() => {
+beforeEach(() => {
   configOptions = {
     pjson: {
       name: 'analytics',


### PR DESCRIPTION
@KarateCowboy could you review?  I started writing tests for the changes I am working on and was getting errors because `configOptions` gets set once and a test alters it so it throws off other tests.