### PR TITLE
Fix mock returning a string rather than object

### DIFF
--- a/src/config.test.js
+++ b/src/config.test.js
@@ -68,7 +68,7 @@ test('loads the user config when present', () => {
 
 describe('skipAnalytics', () => {
   it('returns true when testing environment is set to "1"', () => {
-    mockUserConfig = '{ "skipAnalytics": false }'
+    mockUserConfig = { 'skipAnalytics': false }
     fs.readJSONSync = jest.fn(() => { return mockUserConfig })
     process.env['TESTING'] = '1'
     let sampleConfig = buildConfig(configOptions)


### PR DESCRIPTION
@KarateCowboy one of the mocks returns a string rather than object which was breaking a test I was working on in my branch