### PR TITLE
config root fix for cli-engine-command <= 9.x

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -227,8 +227,8 @@ function validatePJSON(pjson: PJSON) {
 }
 
 export interface RunReturn {
-  +stdout?: string;
-  +stderr?: string;
+  +stdout?: string,
+  +stderr?: string,
 }
 
 export type Arg = {
@@ -329,26 +329,27 @@ export type Plugin = {
 }
 
 export interface ICommand {
-  +topic?: string;
-  +command?: ?string;
-  +description: ?string;
-  +hidden: ?boolean;
-  +usage: ?string;
-  +help: ?string;
-  +aliases: string[];
-  +_version: string;
-  +id: string;
-  +buildHelp?: (config: Config) => string;
-  +buildHelpLine?: (config: Config) => [string, ?string];
-  +args?: Arg[];
-  +flags?: { [name: string]: BooleanFlag | OptionFlag<*> };
-  +run: (options: ?ConfigOptions) => Promise<RunReturn>;
-  plugin?: ?Plugin;
+  +topic?: string,
+  +command?: ?string,
+  +description: ?string,
+  +hidden: ?boolean,
+  +usage: ?string,
+  +help: ?string,
+  +aliases: string[],
+  +_version: string,
+  +id: string,
+  +buildHelp?: (config: Config) => string,
+  +buildHelpLine?: (config: Config) => [string, ?string],
+  +args?: Arg[],
+  +flags?: { [name: string]: BooleanFlag | OptionFlag<*> },
+  +run: (options: ?ConfigOptions) => Promise<RunReturn>,
+  plugin?: ?Plugin,
 }
 
 export function buildConfig(existing: ?ConfigOptions = {}): Config {
   if (!existing) existing = {}
-  if (existing._version) return (existing: any)
+  if (existing._version && existing._version === '1') return (existing: any)
+  if (!existing.root && existing.opts && existing.opts.root) existing.root = existing.opts.root
   if (existing.root && !existing.pjson) {
     let pjsonPath = path.join(existing.root, 'package.json')
     if (fs.existsSync(pjsonPath)) {

--- a/src/config.js
+++ b/src/config.js
@@ -324,26 +324,26 @@ export type OptionFlag<T> = Flag & {
 }
 
 export type Plugin = {
-  +name: string,
-  +version: string,
+  +name: string;
+  +version: string;
 }
 
 export interface ICommand {
-  +topic?: string,
-  +command?: ?string,
-  +description: ?string,
-  +hidden: ?boolean,
-  +usage: ?string,
-  +help: ?string,
-  +aliases: string[],
-  +_version: string,
-  +id: string,
-  +buildHelp?: (config: Config) => string,
-  +buildHelpLine?: (config: Config) => [string, ?string],
-  +args?: Arg[],
-  +flags?: { [name: string]: BooleanFlag | OptionFlag<*> },
-  +run: (options: ?ConfigOptions) => Promise<RunReturn>,
-  plugin?: ?Plugin,
+  +topic?: string;
+  +command?: ?string;
+  +description: ?string;
+  +hidden: ?boolean;
+  +usage: ?string;
+  +help: ?string;
+  +aliases: string[];
+  +_version: string;
+  +id: string;
+  +buildHelp?: (config: Config) => string;
+  +buildHelpLine?: (config: Config) => [string, ?string];
+  +args?: Arg[];
+  +flags?: { [name: string]: BooleanFlag | OptionFlag<*> };
+  +run: (options: ?ConfigOptions) => Promise<RunReturn>;
+  plugin?: ?Plugin;
 }
 
 export function buildConfig(existing: ?ConfigOptions = {}): Config {

--- a/src/config.js
+++ b/src/config.js
@@ -227,8 +227,8 @@ function validatePJSON(pjson: PJSON) {
 }
 
 export interface RunReturn {
-  +stdout?: string,
-  +stderr?: string,
+  +stdout?: string;
+  +stderr?: string;
 }
 
 export type Arg = {
@@ -324,8 +324,8 @@ export type OptionFlag<T> = Flag & {
 }
 
 export type Plugin = {
-  +name: string;
-  +version: string;
+  +name: string,
+  +version: string,
 }
 
 export interface ICommand {


### PR DESCRIPTION
@jdxcode fix to get `this.config` to look correct in `cli-engine-command <= 9.x`